### PR TITLE
Add Smithery CLI Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Tinybird MCP server
 
+[![smithery badge](https://smithery.ai/badge/mcp-tinybird)](https://smithery.ai/protocol/mcp-tinybird)
 An MCP server to interact with a Tinybird Workspace from any MCP client.
 
 ## Features
@@ -16,6 +17,14 @@ An MCP server to interact with a Tinybird Workspace from any MCP client.
 ## Setup
 
 ### Installation
+
+### Installing via Smithery
+
+To install Tinybird MCP for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/mcp-tinybird):
+
+```bash
+npx @smithery/cli install mcp-tinybird --client claude
+```
 
 You can install the Tinybird MCP server using mcp-get:
 


### PR DESCRIPTION
This PR adds installation instructions to automatically install Tinybird MCP for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP. Also, it adds a badge to show the number of installations from Smithery.